### PR TITLE
add a verbose flag and make PN buildable for CAF devices

### DIFF
--- a/build/core/mtk_target.mk
+++ b/build/core/mtk_target.mk
@@ -1,0 +1,13 @@
+ifeq ($(BOARD_USES_MTK_HARDWARE),true)
+    mtk_flags := -DMTK_HARDWARE
+
+    TARGET_GLOBAL_CFLAGS += $(mtk_flags)
+    TARGET_GLOBAL_CPPFLAGS += $(mtk_flags)
+    CLANG_TARGET_GLOBAL_CFLAGS += $(mtk_flags)
+    CLANG_TARGET_GLOBAL_CPPFLAGS += $(mtk_flags)
+
+    2ND_TARGET_GLOBAL_CFLAGS += $(mtk_flags)
+    2ND_TARGET_GLOBAL_CPPFLAGS += $(mtk_flags)
+    2ND_CLANG_TARGET_GLOBAL_CFLAGS += $(mtk_flags)
+    2ND_CLANG_TARGET_GLOBAL_CPPFLAGS += $(mtk_flags)
+endif

--- a/build/core/mtk_utils.mk
+++ b/build/core/mtk_utils.mk
@@ -1,0 +1,5 @@
+# Board platforms lists to be used for
+# TARGET_BOARD_PLATFORM specific featurization
+MTK_BOARD_PLATFORMS := mt6592
+MTK_BOARD_PLATFORMS += mt6582
+MTK_BOARD_PLATFORMS += mt6572

--- a/build/core/qcom_target.mk
+++ b/build/core/qcom_target.mk
@@ -1,0 +1,133 @@
+# Target-specific configuration
+
+# Populate the qcom hardware variants in the project pathmap.
+define ril-set-path-variant
+$(call project-set-path-variant,ril,TARGET_RIL_VARIANT,hardware/$(1))
+endef
+define wlan-set-path-variant
+$(call project-set-path-variant,wlan,TARGET_WLAN_VARIANT,hardware/qcom/$(1))
+endef
+define bt-vendor-set-path-variant
+$(call project-set-path-variant,bt-vendor,TARGET_BT_VENDOR_VARIANT,hardware/qcom/$(1))
+endef
+
+# Set device-specific HALs into project pathmap
+define set-device-specific-path
+$(if $(USE_DEVICE_SPECIFIC_$(1)), \
+    $(if $(DEVICE_SPECIFIC_$(1)_PATH), \
+        $(eval path := $(DEVICE_SPECIFIC_$(1)_PATH)), \
+        $(eval path := $(TARGET_DEVICE_DIR)/$(2))), \
+    $(eval path := $(3))) \
+$(call project-set-path,qcom-$(2),$(strip $(path)))
+endef
+
+ifeq ($(BOARD_USES_QCOM_HARDWARE),true)
+
+    qcom_flags := -DQCOM_HARDWARE
+    qcom_flags += -DQCOM_BSP
+    qcom_flags += -DQTI_BSP
+
+    TARGET_USES_QCOM_BSP := true
+
+    # Tell HALs that we're compiling an AOSP build with an in-line kernel
+    TARGET_COMPILE_WITH_MSM_KERNEL := true
+
+    ifneq ($(filter msm7x27a msm7x30 msm8660 msm8960,$(TARGET_BOARD_PLATFORM)),)
+        # Enable legacy graphics functions
+        qcom_flags += -DQCOM_BSP_LEGACY
+        # Enable legacy audio functions
+        ifeq ($(BOARD_USES_LEGACY_ALSA_AUDIO),true)
+            USE_CUSTOM_AUDIO_POLICY := 1
+            qcom_flags += -DLEGACY_ALSA_AUDIO
+        endif
+    endif
+
+    # Enable extra offloading for post-805 targets
+    ifneq ($(filter msm8992 msm8994,$(TARGET_BOARD_PLATFORM)),)
+        qcom_flags += -DHAS_EXTRA_FLAC_METADATA
+    endif
+
+    TARGET_GLOBAL_CFLAGS += $(qcom_flags)
+    TARGET_GLOBAL_CPPFLAGS += $(qcom_flags)
+    CLANG_TARGET_GLOBAL_CFLAGS += $(qcom_flags)
+    CLANG_TARGET_GLOBAL_CPPFLAGS += $(qcom_flags)
+
+    # Multiarch needs these too..
+    2ND_TARGET_GLOBAL_CFLAGS += $(qcom_flags)
+    2ND_TARGET_GLOBAL_CPPFLAGS += $(qcom_flags)
+    2ND_CLANG_TARGET_GLOBAL_CFLAGS += $(qcom_flags)
+    2ND_CLANG_TARGET_GLOBAL_CPPFLAGS += $(qcom_flags)
+
+    ifeq ($(QCOM_HARDWARE_VARIANT),)
+        ifneq ($(filter msm8610 msm8226 msm8974,$(TARGET_BOARD_PLATFORM)),)
+            QCOM_HARDWARE_VARIANT := msm8974
+        else
+        ifneq ($(filter msm8909 msm8916,$(TARGET_BOARD_PLATFORM)),)
+            QCOM_HARDWARE_VARIANT := msm8916
+        else
+        ifneq ($(filter msm8953 msm8937,$(TARGET_BOARD_PLATFORM)),)
+            QCOM_HARDWARE_VARIANT := msm8937
+        else
+        ifneq ($(filter msm8992 msm8994,$(TARGET_BOARD_PLATFORM)),)
+            QCOM_HARDWARE_VARIANT := msm8994
+        else
+            QCOM_HARDWARE_VARIANT := $(TARGET_BOARD_PLATFORM)
+        endif
+        endif
+        endif
+        endif
+    endif
+
+# HACK: check to see if build uses standard QC HAL paths by checking for CM path structure
+AOSP_VARIANT_MAKEFILE := $(wildcard hardware/qcom/audio/default/Android.mk)
+ifeq ("$(AOSP_VARIANT_MAKEFILE)","")
+$(call project-set-path,qcom-audio,hardware/qcom/audio)
+$(call project-set-path,qcom-display,hardware/qcom/display)
+$(call project-set-path,qcom-media,hardware/qcom/media)
+$(call set-device-specific-path,CAMERA,camera,hardware/qcom/camera)
+$(call set-device-specific-path,GPS,gps,hardware/qcom/gps)
+$(call set-device-specific-path,SENSORS,sensors,hardware/qcom/sensors)
+$(call set-device-specific-path,LOC_API,loc-api,vendor/qcom/opensource/location)
+$(call set-device-specific-path,DATASERVICES,dataservices,vendor/qcom/opensource/dataservices)
+$(call project-set-path,ril,hardware/ril)
+$(call project-set-path,wlan,hardware/qcom/wlan)
+$(call project-set-path,bt-vendor,hardware/qcom/bt)
+else
+$(call project-set-path,qcom-audio,hardware/qcom/audio-caf/$(QCOM_HARDWARE_VARIANT))
+
+ifeq ($(SONY_BF64_KERNEL_VARIANT),true)
+$(call project-set-path,qcom-display,hardware/qcom/display-caf/sony)
+$(call project-set-path,qcom-media,hardware/qcom/media-caf/sony)
+else
+$(call project-set-path,qcom-display,hardware/qcom/display-caf/$(QCOM_HARDWARE_VARIANT))
+$(call project-set-path,qcom-media,hardware/qcom/media-caf/$(QCOM_HARDWARE_VARIANT))
+endif
+
+$(call set-device-specific-path,CAMERA,camera,hardware/qcom/camera)
+$(call set-device-specific-path,GPS,gps,hardware/qcom/gps)
+$(call set-device-specific-path,SENSORS,sensors,hardware/qcom/sensors)
+$(call set-device-specific-path,LOC_API,loc-api,vendor/qcom/opensource/location)
+$(call set-device-specific-path,DATASERVICES,dataservices,vendor/qcom/opensource/dataservices)
+
+$(call ril-set-path-variant,ril)
+$(call wlan-set-path-variant,wlan-caf)
+$(call bt-vendor-set-path-variant,bt-caf)
+endif # AOSP_VARIANT_MAKEFILE
+
+else
+
+$(call project-set-path,qcom-audio,hardware/qcom/audio/default)
+$(call project-set-path,qcom-display,hardware/qcom/display/$(TARGET_BOARD_PLATFORM))
+$(call project-set-path,qcom-media,hardware/qcom/media)
+
+$(call project-set-path,qcom-camera,hardware/qcom/camera)
+$(call project-set-path,qcom-gps,hardware/qcom/gps)
+$(call project-set-path,qcom-sensors,hardware/qcom/sensors)
+$(call project-set-path,qcom-loc-api,vendor/qcom/opensource/location)
+$(call project-set-path,qcom-dataservices,$(TARGET_DEVICE_DIR)/dataservices)
+
+$(call ril-set-path-variant,ril)
+$(call wlan-set-path-variant,wlan)
+$(call bt-vendor-set-path-variant,bt)
+
+endif

--- a/build/core/qcom_utils.mk
+++ b/build/core/qcom_utils.mk
@@ -1,0 +1,230 @@
+# Board platforms lists to be used for
+# TARGET_BOARD_PLATFORM specific featurization
+QCOM_BOARD_PLATFORMS += msm7x27a
+QCOM_BOARD_PLATFORMS += msm7x30
+QCOM_BOARD_PLATFORMS += msm8226
+QCOM_BOARD_PLATFORMS += msm8610
+QCOM_BOARD_PLATFORMS += msm8660
+QCOM_BOARD_PLATFORMS += msm8909
+QCOM_BOARD_PLATFORMS += msm8916
+QCOM_BOARD_PLATFORMS += msm8960
+QCOM_BOARD_PLATFORMS += msm8974
+QCOM_BOARD_PLATFORMS += mpq8092
+QCOM_BOARD_PLATFORMS += msm8937
+QCOM_BOARD_PLATFORMS += msm8952
+QCOM_BOARD_PLATFORMS += msm8953
+QCOM_BOARD_PLATFORMS += msm8992
+QCOM_BOARD_PLATFORMS += msm8994
+QCOM_BOARD_PLATFORMS += msm8996
+QCOM_BOARD_PLATFORMS += msm_bronze
+QCOM_BOARD_PLATFORMS += apq8084
+
+MSM7K_BOARD_PLATFORMS := msm7x30
+MSM7K_BOARD_PLATFORMS += msm7x27
+MSM7K_BOARD_PLATFORMS += msm7x27a
+MSM7K_BOARD_PLATFORMS += msm7k
+
+QSD8K_BOARD_PLATFORMS := qsd8k
+
+
+# vars for use by utils
+empty :=
+space := $(empty) $(empty)
+colon := $(empty):$(empty)
+underscore := $(empty)_$(empty)
+
+# $(call match-word,w1,w2)
+# checks if w1 == w2
+# How it works
+#   if (w1-w2 not empty or w2-w1 not empty) then not_match else match
+#
+# returns true or empty
+#$(warning :$(1): :$(2): :$(subst $(1),,$(2)):) \
+#$(warning :$(2): :$(1): :$(subst $(2),,$(1)):) \
+#
+define match-word
+$(strip \
+  $(if $(or $(subst $(1),$(empty),$(2)),$(subst $(2),$(empty),$(1))),,true) \
+)
+endef
+
+# $(call find-word-in-list,w,wlist)
+# finds an exact match of word w in word list wlist
+#
+# How it works
+#   fill wlist spaces with colon
+#   wrap w with colon
+#   search word w in list wl, if found match m, return stripped word w
+#
+# returns stripped word or empty
+define find-word-in-list
+$(strip \
+  $(eval wl:= $(colon)$(subst $(space),$(colon),$(strip $(2)))$(colon)) \
+  $(eval w:= $(colon)$(strip $(1))$(colon)) \
+  $(eval m:= $(findstring $(w),$(wl))) \
+  $(if $(m),$(1),) \
+)
+endef
+
+# $(call match-word-in-list,w,wlist)
+# does an exact match of word w in word list wlist
+# How it works
+#   if the input word is not empty
+#     return output of an exact match of word w in wordlist wlist
+#   else
+#     return empty
+# returns true or empty
+define match-word-in-list
+$(strip \
+  $(if $(strip $(1)), \
+    $(call match-word,$(call find-word-in-list,$(1),$(2)),$(strip $(1))), \
+  ) \
+)
+endef
+
+# $(call match-prefix,p,delim,w/wlist)
+# matches prefix p in wlist using delimiter delim
+#
+# How it works
+#   trim the words in wlist w
+#   if find-word-in-list returns not empty
+#     return true
+#   else
+#     return empty
+#
+define match-prefix
+$(strip \
+  $(eval w := $(strip $(1)$(strip $(2)))) \
+  $(eval text := $(patsubst $(w)%,$(1),$(3))) \
+  $(if $(call match-word-in-list,$(1),$(text)),true,) \
+)
+endef
+
+# ----
+# The following utilities are meant for board platform specific
+# featurisation
+
+# $(call get-vendor-board-platforms,v)
+# returns list of board platforms for vendor v
+define get-vendor-board-platforms
+$(if $(call match-word,$(BOARD_USES_$(1)_HARDWARE),true),$($(1)_BOARD_PLATFORMS))
+endef
+
+# $(call is-board-platform,bp)
+# returns true or empty
+define is-board-platform
+$(call match-word,$(1),$(TARGET_BOARD_PLATFORM))
+endef
+
+# $(call is-not-board-platform,bp)
+# returns true or empty
+define is-not-board-platform
+$(if $(call match-word,$(1),$(TARGET_BOARD_PLATFORM)),,true)
+endef
+
+# $(call is-board-platform-in-list,bpl)
+# returns true or empty
+define is-board-platform-in-list
+$(call match-word-in-list,$(TARGET_BOARD_PLATFORM),$(1))
+endef
+
+# $(call is-vendor-board-platform,vendor)
+# returns true or empty
+define is-vendor-board-platform
+$(strip \
+  $(call match-word-in-list,$(TARGET_BOARD_PLATFORM),\
+    $(call get-vendor-board-platforms,$(1)) \
+  ) \
+)
+endef
+
+# $(call is-chipset-in-board-platform,chipset)
+# does a prefix match of chipset in TARGET_BOARD_PLATFORM
+# uses underscore as a delimiter
+#
+# returns true or empty
+define is-chipset-in-board-platform
+$(call match-prefix,$(1),$(underscore),$(TARGET_BOARD_PLATFORM))
+endef
+
+# $(call is-chipset-prefix-in-board-platform,prefix)
+# does a chipset prefix match in TARGET_BOARD_PLATFORM
+# assumes '_' and 'a' as the delimiter to the chipset prefix
+#
+# How it works
+#   if ($(prefix)_ or $(prefix)a match in board platform)
+#     return true
+#   else
+#     return empty
+#
+define is-chipset-prefix-in-board-platform
+$(strip \
+  $(eval delim_a := $(empty)a$(empty)) \
+  $(if \
+    $(or \
+      $(call match-prefix,$(1),$(delim_a),$(TARGET_BOARD_PLATFORM)), \
+      $(call match-prefix,$(1),$(underscore),$(TARGET_BOARD_PLATFORM)), \
+    ), \
+    true, \
+  ) \
+)
+endef
+
+#----
+# The following utilities are meant for Android Code Name
+# specific featurisation
+#
+# refer http://source.android.com/source/build-numbers.html
+# for code names and associated sdk versions
+CUPCAKE_SDK_VERSIONS := 3
+DONUT_SDK_VERSIONS   := 4
+ECLAIR_SDK_VERSIONS  := 5 6 7
+FROYO_SDK_VERSIONS   := 8
+GINGERBREAD_SDK_VERSIONS := 9 10
+HONEYCOMB_SDK_VERSIONS := 11 12 13
+ICECREAM_SANDWICH_SDK_VERSIONS := 14 15
+JELLY_BEAN_SDK_VERSIONS := 16 17 18
+
+# $(call is-platform-sdk-version-at-least,version)
+# version is a numeric SDK_VERSION defined above
+define is-platform-sdk-version-at-least
+$(strip \
+  $(if $(filter 1,$(shell echo "$$(( $(PLATFORM_SDK_VERSION) >= $(1) ))" )), \
+    true, \
+  ) \
+)
+endef
+
+# $(call is-android-codename,codename)
+# codename is one of cupcake,donut,eclair,froyo,gingerbread,icecream
+# please refer the $(codename)_SDK_VERSIONS declared above
+define is-android-codename
+$(strip \
+  $(if \
+    $(call match-word-in-list,$(PLATFORM_SDK_VERSION),$($(1)_SDK_VERSIONS)), \
+    true, \
+  ) \
+)
+endef
+
+# $(call is-android-codename-in-list,cnlist)
+# cnlist is combination/list of android codenames
+define is-android-codename-in-list
+$(strip \
+  $(eval acn := $(empty)) \
+    $(foreach \
+      i,$(1),\
+      $(eval acn += \
+        $(if \
+          $(call \
+            match-word-in-list,\
+            $(PLATFORM_SDK_VERSION),\
+            $($(i)_SDK_VERSIONS)\
+          ),\
+          true,\
+        )\
+      )\
+    ) \
+  $(if $(strip $(acn)),true,) \
+)
+endef

--- a/core/main.mk
+++ b/core/main.mk
@@ -552,7 +552,18 @@ ifeq ($(USE_SOONG),true)
 subdir_makefiles := $(SOONG_ANDROID_MK) $(call filter-soong-makefiles,$(subdir_makefiles))
 endif
 
+ifeq ($(VERBOSE_OUPUT),true)
+$(foreach mk, $(subdir_makefiles), \
+  $(info Including Makefile: $(mk)) \
+  $(eval include $(mk)) \
+  $(checking deps of modules from ===> $(mk)) \
+  $(eval LOCAL_MODULE \:=$(mk)) \
+  $(eval LOCAL_DIR \:= $(patsubst %/,%,$(dir $(mk)))) \
+  $(info =======> LOCAL_MODULE =======> $(LOCAL_MODULE)) \
+)
+else
 $(foreach mk, $(subdir_makefiles), $(eval include $(mk)))
+endif
 
 ifdef PDK_FUSION_PLATFORM_ZIP
 # Bring in the PDK platform.zip modules.


### PR DESCRIPTION
When building for CAF devices we need that qcom_target.mk and and qcom_utils.mk so the caf dirs are picked up when audio, ril, display etc are evaluated for the target device. 


Verbose output is dope. So no explanation there, outputs LOCALE_MODULE name and dir currently being eval'd, see below.

```
============================================
Including Makefile: ./abi/cpp/Android.mk
=======> LOCAL_MODULE =======> libgabi++
Including Makefile: ./art/Android.mk
=======> LOCAL_MODULE =======> openjdkjvm-phony
Including Makefile: ./bionic/Android.mk
=======> LOCAL_MODULE =======> tzdata-host
Including Makefile: ./bootable/recovery/Android.mk
=======> LOCAL_MODULE =======> update_verifier
Including Makefile: ./build/libs/host/Android.mk
=======> LOCAL_MODULE =======> libhost
Including Makefile: ./build/target/board/Android.mk
=======> LOCAL_MODULE =======> libhost

```